### PR TITLE
ci: allow xargs to process files with special characters

### DIFF
--- a/.github/workflows/lint-files.yml
+++ b/.github/workflows/lint-files.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Validate YAML file
-        run: find . \( -name "*.yml" -o -name "*.yaml" \) | xargs yamllint -c .yamllint.yml --strict
+        run: find . -print0 \( -name "*.yml" -o -name "*.yaml" \) | xargs yamllint -c .yamllint.yml --strict
 
   lint-markdown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
SC2038: Use -print0/-0 or find -exec + to allow for non-alphanumeric filenames.

https://www.shellcheck.net/wiki/SC2038