### PR TITLE
ci: use `xargs -0` as `-print0` is used with `find`

### DIFF
--- a/.github/workflows/lint-files.yml
+++ b/.github/workflows/lint-files.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Validate YAML file
-        run: find . -print0 \( -name "*.yml" -o -name "*.yaml" \) | xargs yamllint -c .yamllint.yml --strict
+        run: find . -print0 \( -name "*.yml" -o -name "*.yaml" \) | xargs -0 yamllint -c .yamllint.yml --strict
 
   lint-markdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-files.yml
+++ b/.github/workflows/lint-files.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Validate YAML file
-        run: find . -print0 \( -name "*.yml" -o -name "*.yaml" \) | xargs -0 yamllint -c .yamllint.yml --strict
+        run: find . \( -name "*.yml" -o -name "*.yaml" \) -print0 | xargs -0 yamllint -c .yamllint.yml --strict
 
   lint-markdown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
... otherwise `xargs` creates a warning and shellcheck also reports an error.