### PR TITLE
chore: allow 132 character per line in markdown files

### DIFF
--- a/.github/workflows/lint-files.yml
+++ b/.github/workflows/lint-files.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Validate Markdown file
         run: |
           npm install -g markdownlint-cli
-          markdownlint "**/*.md"
+          markdownlint -c .markdownlint.yml "**/*.md"
 
   lint-workflow:
     runs-on: ubuntu-latest

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,12 @@
+---
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 132
+  # Number of characters for headings
+  heading_line_length: 132
+  # Number of characters for code blocks
+  code_block_line_length: 132

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the content of my blog Tech@Work.
 
-## Workflows
+## WorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflows
 
 - lints all YAML files
 - lints all Markdown files

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the content of my blog Tech@Work.
 
-## WorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflowsWorkflows
+## Workflows
 
 - lints all YAML files
 - lints all Markdown files


### PR DESCRIPTION
... as we all have wide screens. 80 characters per line is not sufficient.