### PR TITLE
fix: escape liquid template variables

### DIFF
--- a/src/_posts/2022-08-24-lint-pr.md
+++ b/src/_posts/2022-08-24-lint-pr.md
@@ -1,0 +1,42 @@
+---
+date: 2022-08-24
+title: "Linting Pull Requests"
+---
+We use the Pull Request title and description as commit message for the `master` branch as we always squash the
+commits from the feature branch for a clean history. I have seen so many bad commit messages (and
+sometimes I also use "x" or some automatically generated text) that it is better to squash everything. This way you
+can focus on the Pull Request description without thinking too much about a single commit message (it's a documentation
+of your ongoing work). But now it is important to have a good description in the Pull Request as it becomes part
+of commit history.
+
+Furthermore, we use the commit history to generate the release documentation. But it has to follow a certain format otherwise
+we can't process it automatically. That's the reason why we lint the Pull Request.
+
+There are several standards out there. We follow the Angular convention of
+[Conventional Commits](https://https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary).
+
+# How to lint a Pull Request
+
+There is a great action available on GitHub: [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)
+It's well documented and easy to use. In case your Pull Request does not follow the specification, the pipeline is
+red and you have to do your homework.
+
+```yaml
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/src/_posts/2022-08-24-lint-pr.md
+++ b/src/_posts/2022-08-24-lint-pr.md
@@ -38,5 +38,5 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ "{{ secrets.GITHUB_TOKEN " }}}}
 ```

--- a/src/_posts/2022-08-24-lint-pr.md
+++ b/src/_posts/2022-08-24-lint-pr.md
@@ -15,7 +15,7 @@ we can't process it automatically. That's the reason why we lint the Pull Reques
 There are several standards out there. We follow the Angular convention of
 [Conventional Commits](https://https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary).
 
-# How to lint a Pull Request
+## How to lint a Pull Request
 
 There is a great action available on GitHub: [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)
 It's well documented and easy to use. In case your Pull Request does not follow the specification, the pipeline is


### PR DESCRIPTION
`{{ variable }}` is interpreted by the the Liquid layout of Jekyll. Escape it!