### PR TITLE
chore: add comment ids for existing posts

### DIFF
--- a/src/_posts/2022-07-01-why-this-blog.md
+++ b/src/_posts/2022-07-01-why-this-blog.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 43
 date: 2022-07-01
 title: Why this blog?
 ---

--- a/src/_posts/2022-07-13-dependabot.md
+++ b/src/_posts/2022-07-13-dependabot.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 44
 date: 2022-07-13
 title: Updating dependencies with Dependabot on a regular interval
 ---

--- a/src/_posts/2022-07-25-faster-commandline-git.md
+++ b/src/_posts/2022-07-25-faster-commandline-git.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 45
 date: 2022-07-25
 title: Be faster on the command line with Git
 ---

--- a/src/_posts/2022-08-12-faster-commandline-glab.md
+++ b/src/_posts/2022-08-12-faster-commandline-glab.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 46
 date: 2022-08-12
 title: Be faster on the command line with GLab CLI
 ---

--- a/src/_posts/2022-08-24-lint-pr.md
+++ b/src/_posts/2022-08-24-lint-pr.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 47
 date: 2022-08-24
 title: "Linting Pull Requests"
 ---

--- a/src/_posts/2022-09-07-pr-template.md
+++ b/src/_posts/2022-09-07-pr-template.md
@@ -1,4 +1,5 @@
 ---
+comment_id: 48
 date: 2022-09-07
 title: "Templates for Pull Requests"
 ---


### PR DESCRIPTION
Adds the `comment_id` to all existing posts. For new posts this will be done automatically by the pipeline.

Solves part of #34 