### PR TITLE
fix: use `comments_id` instead of `comment_id`

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -68,7 +68,7 @@ jobs:
             echo "New post found: $new_post"
 
             title=$(sed -n -e 's/^.*title: //p' "$new_post" | tr -d '"')
-            issue_id=$(sed -n -e 's/^.*comment_id: //p' "$new_post")
+            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post")
 
             if [ -z "$issue_id" ]; then
               issue_response=$(curl -X "POST" "https://api.github.com/repos/kayman-mk/blog-tech-at-work/issues" \
@@ -87,7 +87,7 @@ jobs:
               issue_id=$(echo "$issue_response" | jq -r .number)
               echo "Created GitHub issue: $issue_id"
 
-              sed -i "2i comment_id: $issue_id" "$new_post"
+              sed -i "2i comments_id: $issue_id" "$new_post"
             fi
           fi
 
@@ -95,7 +95,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         if: github.ref != 'refs/heads/main'
         with:
-          commit_message: "Add comment_id to new post"
+          commit_message: "Add comments_id to new post"
           file_pattern: src/_posts
 
       - name: Deploy

--- a/src/_posts/2022-07-01-why-this-blog.md
+++ b/src/_posts/2022-07-01-why-this-blog.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 43
+comments_id: 43
 date: 2022-07-01
 title: Why this blog?
 ---

--- a/src/_posts/2022-07-13-dependabot.md
+++ b/src/_posts/2022-07-13-dependabot.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 44
+comments_id: 44
 date: 2022-07-13
 title: Updating dependencies with Dependabot on a regular interval
 ---

--- a/src/_posts/2022-07-25-faster-commandline-git.md
+++ b/src/_posts/2022-07-25-faster-commandline-git.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 45
+comments_id: 45
 date: 2022-07-25
 title: Be faster on the command line with Git
 ---

--- a/src/_posts/2022-08-12-faster-commandline-glab.md
+++ b/src/_posts/2022-08-12-faster-commandline-glab.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 46
+comments_id: 46
 date: 2022-08-12
 title: Be faster on the command line with GLab CLI
 ---

--- a/src/_posts/2022-08-24-lint-pr.md
+++ b/src/_posts/2022-08-24-lint-pr.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 47
+comments_id: 47
 date: 2022-08-24
 title: "Linting Pull Requests"
 ---

--- a/src/_posts/2022-09-07-pr-template.md
+++ b/src/_posts/2022-09-07-pr-template.md
@@ -1,5 +1,5 @@
 ---
-comment_id: 48
+comments_id: 48
 date: 2022-09-07
 title: "Templates for Pull Requests"
 ---


### PR DESCRIPTION
`comments_id` is the correct variable proposed by the implementation of the GitHub issues comment system. See #34.