### PR TITLE
fix: enable comments in the built pages

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -39,7 +39,7 @@ jobs:
           cd src
           bundle install
 
-          bundle exec jekyll build
+          JEKYLL_ENV=production bundle exec jekyll build
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
By default Jekyll build in a development mode which does not activate the comments. By setting `JEKYLL_ENV=production` the site is built for the production environment, including everything needed.