### PR TITLE
fix: add missing `comments_id`

### DIFF
--- a/src/_posts/2022-09-19-comment-system-in-static-blog.md
+++ b/src/_posts/2022-09-19-comment-system-in-static-blog.md
@@ -1,4 +1,5 @@
 ---
+comments_id: 65
 date: 2022-09-19
 title: "Implementing a comment System in a static blog"
 ---


### PR DESCRIPTION
The workflow failed, thus this PR adds the `comments_id` of the GitHub issue manually.