### PR TITLE
ci: correct search for issue_id in post

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -74,7 +74,7 @@ jobs:
             echo "New post found: $new_post"
 
             title=$(sed -n -e 's/^.*title: //p' "$new_post" | tr -d '"')
-            issue_id=$(sed -n -e 's/^.*comments_id: [[:digit:]]\+//p' "$new_post")
+            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+)
 
             echo "Title: $title"
             echo "Issue ID: $issue_id"
@@ -116,7 +116,7 @@ jobs:
           if [ -n "$new_post" ]; then
             echo "New post found: $new_post"
 
-            issue_id=$(sed -n -e 's/^.*comments_id: [[:digit:]]\+//p' "$new_post")
+            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+')
 
             curl -X "PATCH" "https://api.github.com/repos/kayman-mk/blog-tech-at-work/issues/$issue_id" \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -74,7 +74,7 @@ jobs:
             echo "New post found: $new_post"
 
             title=$(sed -n -e 's/^.*title: //p' "$new_post" | tr -d '"')
-            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+)
+            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+')
 
             echo "Title: $title"
             echo "Issue ID: $issue_id"

--- a/src/_posts/2022-10-04-data-protection-comment-system.md
+++ b/src/_posts/2022-10-04-data-protection-comment-system.md
@@ -1,5 +1,4 @@
 ---
-comments_id: 70
 comments_id: 69
 date: 2022-10-04
 title: "Protect sensitive data from being exposed to GitHub"


### PR DESCRIPTION
The `sed '.../p'` command finds prefixed lines and returns the remaining line. Thus we shouldn't match the numbers here as they are counted as prefix then. Better to filter this later.

The pipeline created one issue per workflow run and inserted all issued ids into the post.