### PR TITLE
ci: fix exit code in case no issue used for comments is found

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -69,7 +69,7 @@ jobs:
             echo "New post found: $new_post"
 
             title=$(sed -n -e 's/^.*title: //p' "$new_post" | tr -d '"')
-            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+')
+            issue_id=$(sed -n -e 's/^.*comments_id: //p' "$new_post" | grep -Eo '[0-9]+' || true)
 
             echo "Title: $title"
             echo "Issue ID: $issue_id"


### PR DESCRIPTION
... in case the `grep` expression doesn't find an id, it returns 1 and the pipeline fails. Exit code is now ignored.