### PR TITLE
ci: activate future blog post automatically

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -2,10 +2,15 @@
 name: "Build the blog"
 
 on: # yamllint disable-line rule:truthy
+  # feature branches
   pull_request:
+  # releases
   push:
     branches:
       - main
+  # nightly build to automatically activate new blog posts. Slightly after midnight CET/CEST as it is UTC here.
+  schedule:
+    - cron: "22 2 * * *"
 
 jobs:
   build-the-blog:


### PR DESCRIPTION
Runs the build workflow automatically at 2:22 UTC which is slightly after midnight in CET/CEST. Remember that the cron expression is in UTC.