### PR TITLE
ci: exclude jobs in auto-deploy

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -60,13 +60,13 @@ jobs:
           cp node_modules/dayjs/dayjs.min.js target/assets/js/
 
       - id: get-changed-files
-        if: github.event_name != 'schedule'
+        if: ${{ github.event_name != 'schedule' }}
         uses: jitterbit/get-changed-files@v1
         with:
           format: json
 
       - name: Create Github issue for new posts
-        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
+        if: ${{ github.ref }} != 'refs/heads/main' && ${{ github.event_name != 'schedule' }}
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)
@@ -103,13 +103,13 @@ jobs:
 
       - id: commit-changes
         uses: stefanzweifel/git-auto-commit-action@v4
-        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
+        if: ${{ github.ref }} != 'refs/heads/main' && ${{ github.event_name }} != 'schedule'
         with:
           commit_message: "Add comments_id to new post"
           file_pattern: src/_posts
 
       - name: Activate GitHub issue for comments
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.ref }} == 'refs/heads/main'
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)
@@ -132,13 +132,13 @@ jobs:
           fi
 
       - name: Replace secrets
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.ref }} == 'refs/heads/main'
         run: |
           find . -type f -print0 | \
           xargs -0 sed -i "s/__GH_API_TOKEN_COMMENT_SYSTEM__REPLACE_ME__/${{ secrets.GH_API_TOKEN_COMMENT_SYSTEM }}/g"
 
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.ref }} == 'refs/heads/main'
         uses: SamKirkland/FTP-Deploy-Action@4.3.3
         with:
           server: af93d.netcup.net

--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -60,13 +60,13 @@ jobs:
           cp node_modules/dayjs/dayjs.min.js target/assets/js/
 
       - id: get-changed-files
-        if: ${{ github.event_name != 'schedule' }}
+        if: github.event_name != 'schedule'
         uses: jitterbit/get-changed-files@v1
         with:
           format: json
 
       - name: Create Github issue for new posts
-        if: ${{ github.ref }} != 'refs/heads/main' && ${{ github.event_name != 'schedule' }}
+        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)
@@ -103,13 +103,13 @@ jobs:
 
       - id: commit-changes
         uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ github.ref }} != 'refs/heads/main' && ${{ github.event_name }} != 'schedule'
+        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
         with:
           commit_message: "Add comments_id to new post"
           file_pattern: src/_posts
 
       - name: Activate GitHub issue for comments
-        if: ${{ github.ref }} == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)
@@ -132,13 +132,13 @@ jobs:
           fi
 
       - name: Replace secrets
-        if: ${{ github.ref }} == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           find . -type f -print0 | \
           xargs -0 sed -i "s/__GH_API_TOKEN_COMMENT_SYSTEM__REPLACE_ME__/${{ secrets.GH_API_TOKEN_COMMENT_SYSTEM }}/g"
 
       - name: Deploy
-        if: ${{ github.ref }} == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: SamKirkland/FTP-Deploy-Action@4.3.3
         with:
           server: af93d.netcup.net

--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -60,12 +60,13 @@ jobs:
           cp node_modules/dayjs/dayjs.min.js target/assets/js/
 
       - id: get-changed-files
+        if: github.event_name != 'schedule'
         uses: jitterbit/get-changed-files@v1
         with:
           format: json
 
       - name: Create Github issue for new posts
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)
@@ -102,7 +103,7 @@ jobs:
 
       - id: commit-changes
         uses: stefanzweifel/git-auto-commit-action@v4
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.event_name != 'schedule'
         with:
           commit_message: "Add comments_id to new post"
           file_pattern: src/_posts


### PR DESCRIPTION
Exclude some jobs from the workflow for the nightly build by schedule. These jobs are not needed as they deal with changed files in a feature branch. But we deploy the `main` branch here.