### PR TITLE
ci: activate issues in nightly build not needed

### DIFF
--- a/.github/workflows/build-blog.yml
+++ b/.github/workflows/build-blog.yml
@@ -109,7 +109,7 @@ jobs:
           file_pattern: src/_posts
 
       - name: Activate GitHub issue for comments
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'schedule'
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.added }}"
           new_post=$(echo '${{ steps.get-changed-files.outputs.added }}' | jq -r .[] | grep src/_posts || true)


### PR DESCRIPTION
The issues were activated when the article was merged into `main`. So we skip this step and increase the performance a little bit.